### PR TITLE
fix search, remove smooth scroll from search bar

### DIFF
--- a/src/routes/components/buttons/constants.ts
+++ b/src/routes/components/buttons/constants.ts
@@ -355,55 +355,55 @@ export const buttons: ButtonDisplayData[] = [
       tableName: 'buttons',
       rows: [
         {
-          name: 'disabled',
+          name: 'button_disabled',
           description: 'A boolean that indicates whether the button is disabled or not.',
           default: 'false',
           nav: false
         },
         {
-          name: 'size',
+          name: 'button_size',
           description: "A string that indicates the size of the button. The possible values are 'xsmall', 'small','medium', 'large', and 'xlarge'.",
           default: 'medium',
           nav: true
         },
         {
-          name: 'background',
+          name: 'button_background',
           description: "A string that indicates the background color of the button.",
           default: '#c50eff',
           nav: true
         },
         {
-          name: 'color',
+          name: 'button_color',
           description: "A string that indicates the text color of the button.",
           default: '#fff',
           nav: true
         },
         {
-          name: 'isLoading',
+          name: 'button_isLoading',
           description: 'A boolean that indicates whether the button is in a loading state or not. When set to true, the button will be disabled and display a loading spinner.',
           default: 'false',
           nav: false
         },
         {
-          name: 'isError',
+          name: 'button_isError',
           description: 'A boolean that indicates whether the button is in an error state or not. When set to true, the button will be disabled and display an error border.',
           default: 'false',
           nav: false
         },
         {
-          name: 'events',
+          name: 'button_events',
           description: 'You can add event listeners to your button by using the on:click, on:mouseover, on:mouseenter, on:mouseleave, on:focus, on:blur props. The event listener will be passed the event object as the first argument.',
           default: '',
           nav: true
         },
         {
-          name: 'style',
+          name: 'button_style',
           description: 'A string that sets additional styles to the button. This should be a valid CSS string.',
           default: '\'\'',
           nav: true
         },
         {
-          name: 'animated',
+          name: 'button_animated',
           description: 'A boolean that indicates whether the button should animate on click.',
           default: 'false',
           nav: true

--- a/src/routes/components/cards/constants.ts
+++ b/src/routes/components/cards/constants.ts
@@ -317,25 +317,25 @@ export const cards: CardDisplayData[] = [
       tableName: 'cards',
       rows: [
         {
-          name: 'background',
+          name: 'card_background',
           description: 'A string which represents the background color of the entire card.',
           default: 'white',
           nav: true,
         },
         {
-          name: 'style',
+          name: 'card_style',
           description: 'This must be a valid CSS string. This syntax is perfect valid on Card, Card.Head, Card.Content, Card.Foot, and Card.Image',
           default: '""',
           nav: true,
         },
         {
-          name: 'events',
+          name: 'card_events',
           description: 'on:click, on:mouseover, on: mouseenter, on: mouseleave, on: focus, on: blur',
           default: '',
           nav: true,
         },
         {
-          name: 'images',
+          name: 'card_images',
           description: `This is a variant which displays a nicely formatted image on the back of the card. Use: Card.Image`,
           default: '',
           nav: true,

--- a/src/routes/components/checkboxes/constants.ts
+++ b/src/routes/components/checkboxes/constants.ts
@@ -213,37 +213,37 @@ export const checkboxes: CheckboxDisplayData[] = [
       tableName: 'checkboxes',
       rows: [
         {
-          name: 'label',
+          name: 'checkbox_label',
           description: 'The label of the checkbox.',
           default: 'Checkbox',
           nav: true
         },
         {
-          name: 'labelColor',
+          name: 'checkbox_labelColor',
           description: 'The color of the checkbox label.',
           default: 'black',
           nav: false
         },
         {
-          name: 'disabled',
+          name: 'checkbox_disabled',
           description: 'The disabled state of the checkbox.',
           default: 'false',
           nav: true
         },
         {
-          name: 'checked',
+          name: 'checkbox_checked',
           description: 'The checked state of the checkbox.',
           default: 'false',
           nav: false
         },
         {
-          name: 'color',
+          name: 'checkbox_color',
           description: 'The color of the checkbox.',
           default: 'black',
           nav: true
         },
         {
-          name: 'size',
+          name: 'checkbox_size',
           description: 'The size of the checkbox.',
           default: 'medium',
           nav: true

--- a/src/routes/components/inputs/constants.ts
+++ b/src/routes/components/inputs/constants.ts
@@ -207,43 +207,43 @@ export const inputs: InputDisplayData[] = [
       tableName: 'inputs',
       rows: [
         {
-          name: 'background',
+          name: 'input_background',
           description: 'Accepts a string value for the background color of the input.',
           default: '#fff',
           nav: true
         },
         {
-          name: 'color',
+          name: 'input_color',
           description: 'Accepts a string value for the color of the input.',
           default: '#000',
           nav: true
         },
         {
-          name: 'label',
+          name: 'input_label',
           description: 'Accepts a boolean value for the label of the input.',
           default: 'false',
           nav: true
         },
         {
-          name: 'labelIn',
+          name: 'input_labelIn',
           description: 'Accepts a boolean value for the label to be inside the input.',
           default: 'false',
           nav: false
         },
         {
-          name: 'placeholder',
+          name: 'input_placeholder',
           description: 'Accepts a string value for the placeholder of the input.',
           default: '""',
           nav: true
         },
         {
-          name: 'variants',
+          name: 'input_variants',
           description: 'Accepts a string value for the variant of the input. Variants include: default, outline, and line.',
           default: 'default',
           nav: true
         },
         {
-          name: 'prefix',
+          name: 'input_prefix',
           description: 'You can use dot notation to change the input to the prefixed input component. Use: Input.Prefix',
           default: '',
           nav: true

--- a/src/routes/components/radios/constants.ts
+++ b/src/routes/components/radios/constants.ts
@@ -191,43 +191,43 @@ export const radios: RadioDisplayData[] = [
       tableName: 'radios',
       rows: [
         {
-          name: 'options!',
+          name: 'radio_options!',
           description: 'Options is an array of strings that will be used to populate the radio buttons.',
           default: '[]',
           nav: false
         },
         {
-          name: 'groupId!',
+          name: 'radio_groupId!',
           description: 'Group ID is a string that is used to group radio buttons together.',
           default: '\'\'',
           nav: true
         },
         {
-          name: 'color',
+          name: 'radio_color',
           description: 'Color is the color of the radio button.',
           default: '#000',
           nav: true
         },
         {
-          name: 'labelColor',
+          name: 'radio_labelColor',
           description: 'Label color is the color of the label.',
           default: '#000',
           nav: true
         },
         {
-          name: 'size',
+          name: 'radio_size',
           description: 'Size is the size of the radio button.',
           default: 'medium',
           nav: true
         },
         {
-          name: 'disabled',
+          name: 'radio_disabled',
           description: 'Disabled is a boolean that determines if the radio button is disabled.',
           default: 'false',
           nav: true
         },
         {
-          name: 'use',
+          name: 'radio_use',
           description: 'Use is a string that determines if the radio button is used to select one or many options.',
           default: 'one',
           nav: true

--- a/src/ui_components/Search.svelte
+++ b/src/ui_components/Search.svelte
@@ -1,32 +1,21 @@
 <script lang="ts">
-  import { fade, slide } from 'svelte/transition';
-  import Input from '../lib/inputs/Input.svelte';
-  import { MagnifyingGlassIcon } from './icons';
-  import { componentIds } from '../stores/componentStore';
-  import { splitSearchResult } from './utils';
+  import { fade, slide } from "svelte/transition";
+  import Input from "../lib/inputs/Input.svelte";
+  import { MagnifyingGlassIcon } from "./icons";
+  import { componentIds } from "../stores/componentStore";
+  import { splitSearchResult } from "./utils";
 
   $: isOpen = false;
   let searchRef: HTMLDivElement;
 
-  $: searchTerm = '';
+  $: searchTerm = "";
   $: searchResults =
-    searchTerm.toLowerCase() === 'all'
+    searchTerm.toLowerCase() === "all"
       ? $componentIds
       : $componentIds.filter((id) =>
           id.toLowerCase().includes(searchTerm.toLowerCase())
         );
-  $: if (!isOpen) searchTerm = '';
-
-  function handleAnchorClick (event: { preventDefault: () => void; currentTarget: any; }) {
-		event.preventDefault()
-		const link = event.currentTarget
-		const anchorId = new URL(link.href).hash.replace('#', '')
-		const anchor = document.getElementById(anchorId)
-		window.scrollTo({
-			top: anchor?.offsetTop,
-			behavior: 'smooth'
-		})
-	}
+  $: if (!isOpen) searchTerm = "";
 </script>
 
 <svelte:window
@@ -38,7 +27,7 @@
     }
   }}
   on:keydown={(e) => {
-    if (e.key === 'Escape') {
+    if (e.key === "Escape") {
       isOpen = false;
     }
 
@@ -47,21 +36,21 @@
     if (
       isOpen &&
       searchResults.length > 0 &&
-      (e.key === 'ArrowDown' || e.key === 'ArrowUp')
+      (e.key === "ArrowDown" || e.key === "ArrowUp")
     ) {
       e.preventDefault();
       const activeElementId = document.activeElement?.id;
       focusedResultIndex = searchResults.findIndex(
         (id) => id === activeElementId
       );
-      if (e.key === 'ArrowDown') {
+      if (e.key === "ArrowDown") {
         if (focusedResultIndex === -1) {
           document.getElementById(searchResults[0])?.focus();
         } else if (focusedResultIndex < searchResults.length - 1) {
           const nextElementId = searchResults[focusedResultIndex + 1];
           document.getElementById(nextElementId)?.focus();
         }
-      } else if (e.key === 'ArrowUp') {
+      } else if (e.key === "ArrowUp") {
         if (focusedResultIndex === -1) {
           document
             .getElementById(searchResults[searchResults.length - 1])
@@ -75,7 +64,7 @@
   }}
 />
 
-<div class={isOpen ? 'outer expanded' : 'outer'} bind:this={searchRef}>
+<div class={isOpen ? "outer expanded" : "outer"} bind:this={searchRef}>
   <div class="inner">
     {#if isOpen}
       <div
@@ -96,7 +85,7 @@
     >
   </div>
 
-  {#if searchTerm !== ''}
+  {#if searchTerm !== ""}
     {#if searchResults.length === 0}
       <div class="search-results" transition:slide>
         <div class="result">No results found</div>
@@ -105,11 +94,17 @@
       <div class="search-results" transition:slide>
         {#each searchResults as id}
           {@const { component, id: componentId } = splitSearchResult(id)}
-          <a href={`/components?items=${component + 's'}#${componentId}`} {id} on:click={handleAnchorClick}>
+          <a
+            href={`/components?items=${
+              componentId + "s"
+            }#${componentId}_${component}`}
+            {id}
+          >
             <div class="result">
-              <span class="component">{component}</span>:
-              <span class="hash">#</span><span class="property">
-                {componentId}
+              <span class="component">{componentId}</span>:
+              <span class="hash">#</span>
+              <span class="property">
+                {component}
               </span>
             </div>
           </a>

--- a/src/ui_components/displayCard/DisplayPropsTable.svelte
+++ b/src/ui_components/displayCard/DisplayPropsTable.svelte
@@ -2,16 +2,19 @@
   export let table: PropsTable | undefined;
   export let isDarkMode: boolean;
 
-  function handleAnchorClick (event: { preventDefault: () => void; currentTarget: any; }) {
-		event.preventDefault()
-		const link = event.currentTarget
-		const anchorId = new URL(link.href).hash.replace('#', '')
-		const anchor = document.getElementById(anchorId)
-		window.scrollTo({
-			top: anchor?.offsetTop,
-			behavior: 'smooth'
-		})
-	}
+  function handleAnchorClick(event: {
+    preventDefault: () => void;
+    currentTarget: any;
+  }) {
+    event.preventDefault();
+    const link = event.currentTarget;
+    const anchorId = new URL(link.href).hash.replace("#", "");
+    const anchor = document.getElementById(anchorId);
+    window.scrollTo({
+      top: anchor?.offsetTop,
+      behavior: "smooth",
+    });
+  }
 </script>
 
 {#if table}
@@ -41,10 +44,10 @@
                 ].name.replace("!", "")}`}
                 on:click={handleAnchorClick}
               >
-                {table.rows[key].name.replace("!", "")}
+                {table.rows[key].name.replace("!", "").split("_")[1]}
               </a>
             {:else}
-              {table.rows[key].name.replace("!", "")}
+              {table.rows[key].name.replace("!", "").split("_")[1]}
             {/if}
           </td>
           <td>


### PR DESCRIPTION
This PR covers the issue #2.
There were 2 actual issues. First, the IDs were duped and needed to be more specific.
Secondly, the smooth scroll was actually preventing navigation because of the prevent default.